### PR TITLE
Escape asterisk

### DIFF
--- a/local/bin/git-pull-request
+++ b/local/bin/git-pull-request
@@ -8,7 +8,7 @@ set -e
 
 title=$(git show -q --pretty=oneline | cut -d " " -f 2-599)
 
-my_branch=$(git branch | awk '/*/ {print $2}')
+my_branch=$(git branch | awk '/\*/ {print $2}')
 
 github_user=$(git remote show origin | awk -F'/' '/Push/ {print $4}')
 


### PR DESCRIPTION
At macOS you need to escape the asterisk or you will get the following error message:

```
awk: illegal primary in regular expression (*) at )
 source line number 1
 context is
     >>> /(*)/ <<<
```
